### PR TITLE
Fix aiohttp 3.10 breaking changes for NTLM auth

### DIFF
--- a/aiowinrm/sec/request.py
+++ b/aiowinrm/sec/request.py
@@ -6,7 +6,7 @@ class PreparedRequest(object):
     def __init__(self, url, headers, data, session=None, method=None):
         self.url = url
         self.headers = headers
-        self.data = data
+        self.data = data[0] if isinstance(data, tuple) else data
         self.session = session
         self.method = method
 


### PR DESCRIPTION
The 3.10 aiohttp now returns request data as a tuple and it was breaking NTLM auth when re-using it through response.recycle(). I was getting the error:

aiohttp\formdata.py line 117 in add_fields:
TypeError: Only io.IOBase, multidict, and (name, file) pairs allowed, use .add_field() for passing more complex parameters, got b''